### PR TITLE
Bug fix for regular expressions parsing notice message on startup

### DIFF
--- a/src/cec-monitor.js
+++ b/src/cec-monitor.js
@@ -457,16 +457,16 @@ export default class CECMonitor extends EventEmitter {
       }
     }
 
-  	const regexDevice = /base\sdevice:\s\w+\s\((\d{1,2})\),\sHDMI\sport\snumber:\s(\d{1,2}),/gu ;
-  	match = regexDevice.exec(data);
+    const regexDevice = /base\sdevice:\s\w+\s\((\d{1,2})\),\sHDMI\sport\snumber:\s(\d{1,2}),/gu ;
+    match = regexDevice.exec(data);
     if(match) {
       this.address.base = parseInt(match[1], 10);
       this.address.hdmi = parseInt(match[2], 10);
     }
 
-  	const regexPhysical = /physical\saddress:\s([\w\.]+)/gu ;
-  	match = regexPhysical.exec(data);
-  	if(match) {
+    const regexPhysical = /physical\saddress:\s([\w\.]+)/gu ;
+    match = regexPhysical.exec(data);
+    if(match) {
       this.address.physical = match[1].split('.').map(n => parseInt(n, 16)).reduce((a, b) => a = a << 4 | b, 0);
     }
 

--- a/src/cec-monitor.js
+++ b/src/cec-monitor.js
@@ -447,21 +447,27 @@ export default class CECMonitor extends EventEmitter {
   };
 
   _processNotice = function(data) {
-    const regex = /logical\saddress\(es\)\s=\s(Recorder\s\d\s|Playback\s\d\s|Tuner\s\d\s|Audio\s)\(?(\d)\)/gu;
-    let match = regex.exec(data);
+    const regexLogical = /logical\saddress\(es\)\s=\s(Recorder\s\d\s|Playback\s\d\s|Tuner\s\d\s|Audio\s)\(?(\d)\)/gu;
+    let match = regexLogical.exec(data);
     if(match) {
       this.address.primary = parseInt(match[2], 10);
       while(match){
         this.address[match[2]] = true;
-        match = regex.exec(data);
+        match = regexLogical.exec(data);
       }
+    }
 
-      const regextra = /base\sdevice:\s\w+\s\((\d{1,2})\),\sHDMI\sport\snumber:\s(\d{1,2}),\sphysical\saddress:\s([\w\.]+)/gu;
-      match = regextra.exec(data);
-
-      this.address.physical = match[3].split('.').map(n => parseInt(n, 16)).reduce((a, b) => a = a << 4 | b, 0);
+  	const regexDevice = /base\sdevice:\s\w+\s\((\d{1,2})\),\sHDMI\sport\snumber:\s(\d{1,2}),/gu ;
+  	match = regexDevice.exec(data);
+    if(match) {
       this.address.base = parseInt(match[1], 10);
       this.address.hdmi = parseInt(match[2], 10);
+    }
+
+  	const regexPhysical = /physical\saddress:\s([\w\.]+)/gu ;
+  	match = regexPhysical.exec(data);
+  	if(match) {
+      this.address.physical = match[1].split('.').map(n => parseInt(n, 16)).reduce((a, b) => a = a << 4 | b, 0);
     }
 
     return this.emit(CECMonitor.EVENTS._NOTICE, data);


### PR DESCRIPTION
Strings expected by the regexes used sometimes arent output by cec-client, so code changed to accommodate this.

regextra assumes that device, hdmi port number, and physical address are always included in the notice message.  On Raspberry Pi running Raspbian Jessie and with cec-client 1.0.4, this is not the case.  The following notice is emitted:

> NOTICE:  [            1313]        CEC client registered: libCEC version = 4.0.2, client version = 4.0.2, firmware version = 1, logical address(es) = Recorder 1 (1) , physical address: 3.0.0.0, git revision: libcec-4.0.2+8-8563411~dirty, compiled on Sun Apr  2 17:04:01 UTC 2017 by root@hostname: Name or service not known on Linux 4.4.0-57-generic (armv7l), features: P8_USB, DRM, P8_detect, randr, RPi

Referring to [libcec code](https://github.com/Pulse-Eight/libcec/blob/95a1621a5e17691c5f6cbfce4a8b5c2ddaab01d3/src/libcec/CECClient.cpp) for this version on cec-client, lines 1231-1232 show that output is conditional.

So this PR tests for existence of each of the messages, thus allowing the code to work on Raspberry Pi.

Hope everything is in order with this PR.  If any tweaks necessary, by all means make changes as you see appropriate.

Regards,
Damo.