### PR TITLE
Fixed pattern match for case of lost serial connection, rather than s…

### DIFF
--- a/src/cec-monitor.js
+++ b/src/cec-monitor.js
@@ -522,7 +522,7 @@ export default class CECMonitor extends EventEmitter {
       this._processWarning(data)
     } else if(/^ERROR:.*/g.test(data)){
       this._processError(data)
-    } else if(/(^no\sserial\sport\sgiven)|(^Connection\slost)/gu.test(data)){
+    } else if(/(^no serial port given\. trying autodetect: FAILED)|(^Connection lost)/gu.test(data)) {
       if(this.no_serial.reconnect) {
         this.recconnect_intent = true
         this.ready = false


### PR DESCRIPTION
Hi Pablo,

Fixed the pattern match for case of lost serial connection, rather than startup condition of searching for a serial port when none provided to cec-client.

See line 225

of

https://github.com/Pulse-Eight/libcec/blob/e1df683b4248f15fe22f77d08d8f7e48b779c64c/src/cec-client/cec-client.cpp

for the string output by cec-client when connection lost, versus no serial port provided.  The latter should not be an error emission.

Cheers,
Damo.