### PR TITLE
Address parsing refactor

### DIFF
--- a/src/cec-monitor.js
+++ b/src/cec-monitor.js
@@ -522,7 +522,7 @@ export default class CECMonitor extends EventEmitter {
       this._processWarning(data)
     } else if(/^ERROR:.*/g.test(data)){
       this._processError(data)
-    } else if(/(^no\sserial\sport\sgiven)|(^Connection\slost)/gu.test(data)){
+    } else if(/(^no serial port given\. trying autodetect: FAILED)|(^Connection lost)/gu.test(data)) {
       if(this.no_serial.reconnect) {
         this.recconnect_intent = true
         this.ready = false


### PR DESCRIPTION
Hi Pablo,

I've refactored the code that does validation and parsing of addresses, and where necessary converting supplied addresses to the required 'logical' values for sending onto CEC bus.  

In doing so, the same parsing/validation can be performed on all the new methods I added to the library.

No breaking changes, but it does extend the functionality of the `Get` type methods in that they are more tolerant in what addresses are provided to them.  This includes string representations of the logical address from CEC.LogicalAddress.

D.